### PR TITLE
rm double-byte representations for character literals

### DIFF
--- a/lib/linguistics_latin/phonographia.rb
+++ b/lib/linguistics_latin/phonographia.rb
@@ -46,16 +46,6 @@ module Linguistics
     ##
     module Phonographia
       MACRON_TABLE = {
-        "\xc4\x81" => 'a',
-        "\xc4\x93" => 'e',
-        "\xc4\xab" => 'i',
-        "\xc5\x8d" => 'o',
-        "\xc5\xab" => 'u',
-        "\xc4\x80" => 'A',
-        "\xc4\x92" => 'E',
-        "\xc4\xaa" => 'I',
-        "\xc5\x8c" => 'O',
-        "\xc5\xaa" => 'U',
         "ā" => 'a',
         "ē" => 'e',
         "ī" => 'i',


### PR DESCRIPTION
It's much more readable to see "ā" versus "\xc4\x81".

This reduplication was showing up as noise to
STDERR on the startup of the `latinirb` command.